### PR TITLE
Fixed ls_l_r.sh output file name

### DIFF
--- a/verify/ls/ls_l_r.sh
+++ b/verify/ls/ls_l_r.sh
@@ -8,7 +8,7 @@ testfile=$2
 rustybox ls -R -l verify &> $outputfile
 scriptresult=$?
 
-ls -R -l verify | tr -s ' ' | cut -d ' ' -f 1,3,4,5,7,8,9 | grep -v total > output/ls_out
+ls -R -l verify | tr -s ' ' | cut -d ' ' -f 1,3,4,5,7,8,9 | grep -v total > output/.ls_out
 
 node verify/ls/ls.js output/.ls_out $outputfile > $testfile 2>> $outputfile
 testresult=$?


### PR DESCRIPTION
The `ls_l_r.sh` test writes the results to a file, but checks for another file that does not exist.