### PR TITLE
Fixed ls -l missing file error

### DIFF
--- a/verify/ls/ls_l.sh
+++ b/verify/ls/ls_l.sh
@@ -8,7 +8,7 @@ testfile=$2
 rustybox ls -l &> $outputfile
 scriptresult=$?
 
-ls -l | tr -s ' ' | cut -d ' ' -f 1,3,4,5,7,8,9 > output/ls_out
+ls -l | tr -s ' ' | cut -d ' ' -f 1,3,4,5,7,8,9 | grep -v total > output/ls_out
 
 node verify/ls/ls.js output/ls_out $outputfile > $testfile 2>> $outputfile
 testresult=$?


### PR DESCRIPTION
ls -l is printing an extra 'total' line. This should fix it